### PR TITLE
Add issue and pull request templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Logstash
+
+All contributions are welcome: ideas, patches, documentation, bug reports,
+complaints, etc!
+
+Programming is not a required skill, and there are many ways to help out!
+It is more important to us that you are able to contribute.
+
+That said, some basic guidelines, which you are free to ignore :)
+
+## Want to learn?
+
+Want to lurk about and see what others are doing with Logstash? 
+
+* The irc channel (#logstash on irc.freenode.org) is a good place for this
+* The [forum](https://discuss.elastic.co/c/logstash) is also
+  great for learning from others.
+
+## Got Questions?
+
+Have a problem you want Logstash to solve for you? 
+
+* You can ask a question in the [forum](https://discuss.elastic.co/c/logstash)
+* Alternately, you are welcome to join the IRC channel #logstash on
+irc.freenode.org and ask for help there!
+
+## Have an Idea or Feature Request?
+
+* File a ticket on [GitHub](https://github.com/elastic/logstash/issues). Please remember that GitHub is used only for issues and feature requests. If you have a general question, the [forum](https://discuss.elastic.co/c/logstash) or IRC would be the best place to ask.
+
+## Something Not Working? Found a Bug?
+
+If you think you found a bug, it probably is a bug.
+
+* If it is a general Logstash or a pipeline issue, file it in [Logstash GitHub](https://github.com/elasticsearch/logstash/issues)
+* If it is specific to a plugin, please file it in the respective repository under [logstash-plugins](https://github.com/logstash-plugins)
+* or ask the [forum](https://discuss.elastic.co/c/logstash).
+
+# Contributing Documentation and Code Changes
+
+If you have a bugfix or new feature that you would like to contribute to
+logstash, and you think it will take more than a few minutes to produce the fix
+(ie; write code), it is worth discussing the change with the Logstash users and developers first! You can reach us via [GitHub](https://github.com/elastic/logstash/issues), the [forum](https://discuss.elastic.co/c/logstash), or via IRC (#logstash on freenode irc)
+Please note that Pull Requests without tests will not be merged. If you would like to contribute but do not have experience with writing tests, please ping us on IRC/forum or create a PR and ask our help.
+
+## Contributing to plugins
+
+Check our [documentation](https://www.elastic.co/guide/en/logstash/current/contributing-to-logstash.html) on how to contribute to plugins or write your own! It is super easy!
+
+## Contribution Steps
+
+1. Test your changes! [Run](https://github.com/elastic/logstash#testing) the test suite
+2. Please make sure you have signed our [Contributor License
+   Agreement](https://www.elastic.co/contributor-agreement/). We are not
+   asking you to assign copyright to us, but to give us the right to distribute
+   your code without restriction. We ask this of all contributors in order to
+   assure our users of the origin and continuing existence of the code. You
+   only need to sign the CLA once.
+3. Send a pull request! Push your changes to your fork of the repository and
+   [submit a pull
+   request](https://help.github.com/articles/using-pull-requests). In the pull
+   request, describe what your changes do and mention any bugs/issues related
+   to the pull request.
+
+

--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,55 @@
+---
+name: Bug
+about: "Report a confirmed bug. For unconfirmed bugs please
+ visit https://discuss.elastic.co/c/logstash"
+labels: "bug,status:needs-triage"
+
+---
+<!--
+GitHub is reserved for bug reports and feature requests; it is not the place
+for general questions. If you have a question or an unconfirmed bug , please
+visit the [forums](https://discuss.elastic.co/c/logstash).  Please also
+check your OS is [supported](https://www.elastic.co/support/matrix#show_os).
+If it is not, the issue is likely to be closed.
+
+Logstash is located in a different organization: [logstash](https://github.com/elastic/logstash). For bugs specific to Logstash and not related to Logstash Plugins, please open it in the respective Logstash repository.
+
+For security vulnerabilities please only send reports to security@elastic.co.
+See https://www.elastic.co/community/security for more information.
+
+Please fill in the following details to help us reproduce the bug:
+-->
+
+**Logstash information**:
+
+Please include the following information:
+
+1. Logstash version (e.g. `bin/logstash --version`)
+2. Logstash installation source (e.g. built from source, with a package manager: DEB/RPM, expanded from tar or zip archive, docker)
+3. How is Logstash being run (e.g. as a service/service manager: systemd, upstart, etc. Via command line, docker/kubernetes)
+4. How was the Logstash Plugin installed
+
+**JVM** (e.g. `java -version`):
+
+If the affected version of Logstash is 7.9 (or earlier), or if it is NOT using the bundled JDK or using the 'no-jdk' version in 7.10 (or higher), please provide the following information:
+
+1. JVM version (`java -version`)
+2. JVM installation source (e.g. from the Operating System's package manager, from source, etc).
+3. Value of the `JAVA_HOME` environment variable if set.
+
+**OS version** (`uname -a` if on a Unix-like system):
+
+**Description of the problem including expected versus actual behavior**:
+
+**Steps to reproduce**:
+
+Please include a *minimal* but *complete* recreation of the problem,
+including (e.g.) pipeline definition(s), settings, locale, etc.  The easier
+you make for us to reproduce it, the more likely that somebody will take the
+time to look at it.
+
+ 1.
+ 2.
+ 3.
+
+**Provide logs (if relevant)**:

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question
+    url: https://discuss.elastic.co/c/logstash
+    about: Ask (and answer) questions here.
+  - name: Security Vulnerability
+    url: https://www.elastic.co/community/security
+    about: Send security vulnerability reports to security@elastic.co.
+  - name: Logstash Issue
+    url: https://github.com/elastic/logstash
+    about: If your issue has to do with the core of Logstash and not a specific plugin, please file it in the appropriate repository. 

--- a/ISSUE_TEMPLATE/feature-request.md
+++ b/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Request a new feature we haven't thought of
+labels: "enhancement,status:needs-triage"
+
+---
+<!--
+Please first search existing issues for the feature you are requesting;
+it may already exist, even as a closed issue.
+-->
+
+<!--
+Describe the feature.
+
+Please give us as much context as possible about the feature. For example,
+you could include a story about a time when you wanted to use the feature,
+and also tell us what you had to do instead. The last part is helpful
+because it gives us an idea of how much harder your life is without the
+feature.
+
+-->

--- a/ISSUE_TEMPLATE/test-failure.md
+++ b/ISSUE_TEMPLATE/test-failure.md
@@ -1,0 +1,26 @@
+---
+name: Test Failure
+about: A test failure in CI
+labels: "test failure"
+
+---
+
+<!--
+Please fill out the following information, and ensure you have attempted
+to reproduce locally
+-->
+
+**Build scan**:
+
+**Repro line**:
+
+**Reproduces locally?**:
+
+**Applicable branches**:
+
+**Failure history**:
+<!--
+Link to build stats and possible indication of when this started failing and how often it fails
+<https://build-stats.elastic.co/app/kibana>
+-->
+**Failure excerpt**:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,95 @@
+<!-- Type of change
+Please label this PR with the release version and one of the following labels, depending on the scope of your change:
+- bug
+- enhancement
+- breaking change
+- doc
+-->
+
+## Release notes
+<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
+
+
+## What does this PR do?
+
+<!-- Mandatory
+Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
+
+Example:
+  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
+  
+  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
+  being an environment variable to a proper yaml config.
+  
+  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
+-->
+
+## Why is it important/What is the impact to the user?
+
+<!-- Mandatory
+Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.
+
+Example:
+  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
+  and/or
+  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
+-->
+
+## Checklist
+
+<!-- Mandatory
+Add a checklist of things that are required to be reviewed in order to have the PR approved
+
+List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
+-->
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+
+## Author's Checklist
+
+<!-- Recommended
+Add a checklist of things that are required to be reviewed in order to have the PR approved
+-->
+- [ ]
+
+## How to test this PR locally
+
+<!-- Recommended
+Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
+-->
+
+## Related issues
+
+<!-- Recommended
+Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
+
+- Closes #123
+- Relates #123
+- Requires #123
+- Superseeds #123
+-->
+- 
+
+## Use cases
+
+<!-- Recommended
+Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.
+
+If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
+-->
+
+## Screenshots
+
+<!-- Optional
+Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
+-->
+
+## Logs
+
+<!-- Recommended
+Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
+-->

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # .github
+
+Provides common issue and pull request templates.


### PR DESCRIPTION
Adds organization templates to be used for all repositories as per https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file