### PR TITLE
Fix pr-prepare workflow to set fork owner as updatecli input variable

### DIFF
--- a/.github/workflows/pr-prepare.yml
+++ b/.github/workflows/pr-prepare.yml
@@ -83,6 +83,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.token }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
           TARGET_REPOSITORY: ${{ github.event.repository.name }}
           TARGET_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.updatecli/pr-prepare.yml
+++ b/.updatecli/pr-prepare.yml
@@ -9,7 +9,7 @@ scms:
       user: 'github-actions[bot]'
       username: 'github-actions[bot]'
       email: '41898282+github-actions[bot]@users.noreply.github.com'
-      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      owner: '{{ requiredEnv "HEAD_REPO_OWNER" }}'
       repository: '{{ requiredEnv "TARGET_REPOSITORY" }}'
       token: '{{ requiredEnv "GH_TOKEN" }}'
       branch: '{{ requiredEnv "TARGET_BRANCH" }}'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- bug
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Sets the fork owner as updateCLI config parameter to be able to execute changes in the PR head branch. More info at issue description.

## How to test this PR locally
New changes have been tested on: https://github.com/alexcams/logstash-input-tcp/pull/33
Will need this merged for further testing with upstream plugin repo.
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #4 

## Bug reproduction: 
https://github.com/logstash-plugins/logstash-input-elasticsearch/actions/runs/24455810594/job/71456123956?pr=249

