### PR TITLE
Switch comment filtering to check commenter repository permission level instead of membership

### DIFF
--- a/.github/workflows/pr-prepare.yml
+++ b/.github/workflows/pr-prepare.yml
@@ -131,14 +131,22 @@ jobs:
                 owner, repo, issue_number: prNumber, per_page: 100
               });
 
-              // Only consider comments from collaborators, members or the PR author to avoid picking up irrelevant comments.
-              const allowedAssociations = ['COLLABORATOR', 'MEMBER', 'OWNER'];
+              // Only consider comments from users with write or admin access or the PR author.
               const prAuthor = context.payload.pull_request.user.login;
-
-              const prPrepareComments = comments.filter(c =>
-                c.body.trim().startsWith('/pr_prepare') &&
-                (allowedAssociations.includes(c.author_association) || c.user.login === prAuthor)
-              );
+              const candidateComments = comments.filter(c => c.body.trim().startsWith('/pr_prepare'));
+              const prPrepareComments = [];
+              for (const c of candidateComments) {
+                if (c.user.login === prAuthor) {
+                  prPrepareComments.push(c);
+                  continue;
+                }
+                const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: c.user.login
+                });
+                if (['admin', 'write'].includes(perm.permission)) {
+                  prPrepareComments.push(c);
+                }
+              }
               if (prPrepareComments.length === 0) {
                 core.info('No /pr_prepare comment found, skipping');
                 core.setOutput('found', 'false');


### PR DESCRIPTION
Most of Logstash team members have their logstash-plugins ownership private: https://github.com/orgs/logstash-plugins/people
This makes the PR commenter repository association be shown as `CONTRIBUTOR` despite being `OWNER` or `MEMBER`  during workflow execution on PRs where we're not the authors.

With this PR, the workflow will validate the commenter repository permissions instead of the association to accept Changelog entry comments at PRs not created by the commenter.