### PR TITLE
fix: normalize changelog entry and use input PR number on manual dispatch

### DIFF
--- a/.github/workflows/pr-prepare.yml
+++ b/.github/workflows/pr-prepare.yml
@@ -102,13 +102,14 @@ jobs:
                 throw new Error(`PR #${pr.number} is not merged`);
               }
 
-              prNumber = inputPrNumber;
+              prNumber = parseInt(inputPrNumber);
               prTitle = pr.title;
               baseRef = pr.base.ref;
               command = inputCommand;
-              rawEntryText = inputEntry && !inputEntry.startsWith('- ')
-                ? `- ${inputEntry}`
-                : inputEntry;
+              const trimmed = inputEntry ? inputEntry.trim() : inputEntry;
+              rawEntryText = trimmed && !trimmed.startsWith('- ')
+                ? `- ${trimmed}`
+                : trimmed;
 
               const validCommands = ['release:major', 'release:minor', 'release:patch', 'changelog:add'];
               if (!validCommands.includes(command)) {
@@ -247,7 +248,7 @@ jobs:
             if (command === 'changelog:add') {
               const lines = changelog.split('\n');
               if (!lines[0].startsWith('## ')) {
-                throw new Error('CHANGELOG.md does not start with a version header (## x.y.z)');
+                throw new Error('Unexpected CHANGELOG.md format: expected first line to be a version header (e.g. `## x.y.z` or `## Unreleased`)');  
               }
               lines.splice(1, 0, entry);
               newChangelog = lines.join('\n');

--- a/.github/workflows/pr-prepare.yml
+++ b/.github/workflows/pr-prepare.yml
@@ -102,11 +102,13 @@ jobs:
                 throw new Error(`PR #${pr.number} is not merged`);
               }
 
-              prNumber = pr.number;
+              prNumber = inputPrNumber;
               prTitle = pr.title;
               baseRef = pr.base.ref;
               command = inputCommand;
-              rawEntryText = inputEntry;
+              rawEntryText = inputEntry && !inputEntry.startsWith('- ')
+                ? `- ${inputEntry}`
+                : inputEntry;
 
               const validCommands = ['release:major', 'release:minor', 'release:patch', 'changelog:add'];
               if (!validCommands.includes(command)) {

--- a/.github/workflows/pr-prepare.yml
+++ b/.github/workflows/pr-prepare.yml
@@ -176,7 +176,7 @@ jobs:
               });
               entry = formatted.join('\n');
             } else {
-              const unsafeChars = prTitle.match(/[^a-zA-Z0-9 _.,:;+=#@()\-]/g);
+              const unsafeChars = prTitle.match(/[^a-zA-Z0-9 _.,:;+=#@()\-`'!?&~]/g);
               if (unsafeChars) {
                 throw new Error(`PR title contains unsupported characters: ${[...new Set(unsafeChars)].join(' ')}`);
               }
@@ -246,6 +246,9 @@ jobs:
 
             if (command === 'changelog:add') {
               const lines = changelog.split('\n');
+              if (!lines[0].startsWith('## ')) {
+                throw new Error('CHANGELOG.md does not start with a version header (## x.y.z)');
+              }
               lines.splice(1, 0, entry);
               newChangelog = lines.join('\n');
               fs.writeFileSync('new-changelog', newChangelog);


### PR DESCRIPTION
- bug

## Release notes
[rn:skip] 

## What does this PR do?

Manual dispatch runs were producing malformed changelog entries because:

1. `prNumber` was set from `pr.number` (empty for manual workflow dispatch executions) instead of the `inputPrNumber` string, so the PR link in the changelog entry wasn't generated correctly.
2. If the user omitted the - prefix in the changelog entry input, the markdown format wasn't respected — the line wasn't recognized as a list item and the PR link was never appended.

## Example

[This](https://github.com/logstash-plugins/logstash-input-elasticsearch/actions/runs/27575544144/job/81522839208) manual run generated a [wrong Changelog entry](https://github.com/logstash-plugins/logstash-input-elasticsearch/commit/6876062e5d17f1b38d0a314005b93ee84594b455)

## Changes introduced
- Use `inputPrNumber` directly for the PR number in manual dispatch
- Normalize `inputEntry` to prepend '`- `' when the user doesn't include it

## Extra Enhancements:

- Validate that CHANGELOG.md starts with a version header (## x.y.z) before inserting entries, failing with a clear error if the format is unexpected
- Relax PR title character restrictions to allow common characters (` ' ! ? & ~) while still blocking markdown injection vectors ([ ] / ")

## Tests:

- Example commit made by manual workflow run without providing `- `: https://github.com/alexcams/logstash-integration-rabbitmq/commit/cb5d65833adc089eeac3a360e23b0bb930c77d16
It is added by the workflow and the PR link is fine too.
